### PR TITLE
Add an IHttpResponseProcessor to detect a page redirect triggered by JavaScript

### DIFF
--- a/source/Stahp/Stahp.Console/RequestTracerCommand.cs
+++ b/source/Stahp/Stahp.Console/RequestTracerCommand.cs
@@ -85,7 +85,7 @@ namespace Stahp.Console
 
         private CancellationTokenSource DisplayCancellableStatusIndicator()
         {
-            CancellationTokenSource cts = new CancellationTokenSource();
+            CancellationTokenSource cts = new();
             // don't await, because the caller needs to tell the status indicator when to stop
             _console.Status()
                 .StartAsync("Tracing web requests...", async ctx =>
@@ -117,11 +117,12 @@ namespace Stahp.Console
 
             if (traceHop.Redirects)
             {
-                _console.Markup(traceHop.HttpStatusCode switch
+                _console.Markup(traceHop.RedirectType switch
                 {
-                    (>= HttpStatusCode.Moved) and (<= HttpStatusCode.PermanentRedirect) =>
-                        $"HTTP {(int)traceHop.HttpStatusCode} ({traceHop.HttpStatusCode})",
-                    _ => "HTML"
+                    RedirectType.Http => $"HTTP {(int)traceHop.HttpStatusCode!} ({traceHop.HttpStatusCode})",
+                    RedirectType.HtmlMeta => "HTML",
+                    RedirectType.JsHref => "JavaScript",
+                    _ => ""
                 });
                 _console.MarkupLine(" Redirects to...");
 
@@ -129,19 +130,19 @@ namespace Stahp.Console
             }
         }
 
-        private IRenderable PrintHosts(TraceHop traceHop)
+        private static IRenderable PrintHosts(TraceHop traceHop)
         {
             Table? table = new Table()
                 .Border(TableBorder.Minimal);
 
-            List<TableColumn>? columns = new List<TableColumn>()
+            List<TableColumn>? columns = new()
             {
                 new TableColumn("Host Type"),
                 new TableColumn("Host"),
                 new TableColumn("Host Site") { NoWrap = true },
             };
 
-            List<IRenderable>? domainHostRowValues = new List<IRenderable>()
+            List<IRenderable>? domainHostRowValues = new()
             {
                 new Markup("Domain"),
                 new Markup(traceHop.DomainHost?.HostName ?? string.Empty),

--- a/source/Stahp/Stahp.Console/Stahp.Console.csproj
+++ b/source/Stahp/Stahp.Console/Stahp.Console.csproj
@@ -10,10 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="microsoft.extensions.http" Version="6.0.0" />
-    <PackageReference Include="Spectre.Console" Version="0.44.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="microsoft.extensions.http" Version="7.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.46.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
     <PackageReference Include="Whois" Version="3.0.1" />
   </ItemGroup>
 

--- a/source/Stahp/Stahp.Core.Tests/HtmlRedirectProcessorTests.cs
+++ b/source/Stahp/Stahp.Core.Tests/HtmlRedirectProcessorTests.cs
@@ -1,0 +1,89 @@
+using AngleSharp;
+
+using Moq;
+
+using Stahp.Core.HostTypes;
+using Stahp.Core.HttpResponseProcessing;
+
+using System.Net;
+
+namespace Stahp.Core.Tests
+{
+    [TestClass]
+    public class HtmlRedirectProcessorTests
+    {
+        private readonly HtmlRedirectProcessor _processor;
+
+        const string RedirectUrl = "https://www.mozilla.org";
+
+        const string EmptyHtml = "<html></html>";
+        const string EmptyHead = "<html><head></head></html>";
+        const string EmptyBody = "<html><body></body></html>";
+        const string EmptyHeadAndBody = "<html><head></head><body></body></html>";
+        const string MetaCharset = """<html><head><meta charset="utf-8" /></head></html>""";
+        const string MetaAuthor = """<html><head><meta name="author" content="Sebbs128" /></head></html>""";
+        const string MetaHttpEquivContentType = """<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8" /></head></html>""";
+        const string MetaHttpEquivRefreshMozilla = $$"""<html><head><meta http-equiv="refresh" content="3;url={{RedirectUrl}}" /></head></html>""";
+
+        public HtmlRedirectProcessorTests()
+        {
+            IConfiguration config = Configuration.Default;
+
+            var hostFactoryMock = new Mock<IHostFactory>();
+            hostFactoryMock.Setup(f => f.GetHost(It.IsAny<Uri>()))
+                .Returns<Uri>(uri =>
+                {
+                    var host = new Mock<IHost>();
+
+                    host.SetupGet(h => h.HostName)
+                        .Returns(uri.Host);
+                    
+                    host.SetupGet(h => h.HostUrl)
+                        .Returns(uri.ToString());
+                    
+                    return Task.FromResult(host.Object);
+                });
+
+            _processor = new HtmlRedirectProcessor(config, hostFactoryMock.Object);
+        }
+
+        [TestMethod]
+        [DataRow("", DisplayName = "Empty String")]
+        [DataRow(EmptyHtml, DisplayName = nameof(EmptyHtml))]
+        [DataRow(EmptyHead, DisplayName = nameof(EmptyHead))]
+        [DataRow(EmptyBody, DisplayName = nameof(EmptyBody))]
+        [DataRow(EmptyHeadAndBody, DisplayName = nameof(EmptyHeadAndBody))]
+        [DataRow(MetaCharset, DisplayName = nameof(MetaCharset))]
+        [DataRow(MetaAuthor, DisplayName = nameof(MetaAuthor))]
+        [DataRow(MetaHttpEquivContentType, DisplayName = nameof(MetaHttpEquivContentType))]
+        public async Task Process_NoMetaRefreshUrlTags_ReturnsNull(string responseBody)
+        {
+            HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"),
+                Content = new StringContent(responseBody)
+            };
+
+            var result = await _processor.Process(responseMessage);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        [DataRow(MetaHttpEquivRefreshMozilla, RedirectUrl, DisplayName = nameof(MetaHttpEquivRefreshMozilla))]
+        public async Task CanProcess_MetaRefreshUrl_ReturnsRedirectToUrl(string responseBody, string expectedRedirectTargetUrl)
+        {
+            HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"),
+                Content = new StringContent(responseBody)
+            };
+
+            Uri expectedRedirectTarget = new Uri(expectedRedirectTargetUrl);
+
+            var traceHop = await _processor.Process(responseMessage);
+
+            Assert.IsTrue(traceHop is { RedirectType: RedirectType.HtmlMeta } && traceHop.RedirectTargetUrl == expectedRedirectTarget);
+        }
+    }
+}

--- a/source/Stahp/Stahp.Core.Tests/HtmlRedirectProcessorTests.cs
+++ b/source/Stahp/Stahp.Core.Tests/HtmlRedirectProcessorTests.cs
@@ -1,8 +1,5 @@
 using AngleSharp;
 
-using Moq;
-
-using Stahp.Core.HostTypes;
 using Stahp.Core.HttpResponseProcessing;
 
 using System.Net;
@@ -29,22 +26,9 @@ namespace Stahp.Core.Tests
         {
             IConfiguration config = Configuration.Default;
 
-            var hostFactoryMock = new Mock<IHostFactory>();
-            hostFactoryMock.Setup(f => f.GetHost(It.IsAny<Uri>()))
-                .Returns<Uri>(uri =>
-                {
-                    var host = new Mock<IHost>();
+            var hostFactoryMock = Mocks.HostFactory;
 
-                    host.SetupGet(h => h.HostName)
-                        .Returns(uri.Host);
-                    
-                    host.SetupGet(h => h.HostUrl)
-                        .Returns(uri.ToString());
-                    
-                    return Task.FromResult(host.Object);
-                });
-
-            _processor = new HtmlRedirectProcessor(config, hostFactoryMock.Object);
+            _processor = new HtmlRedirectProcessor(config, hostFactoryMock);
         }
 
         [TestMethod]

--- a/source/Stahp/Stahp.Core.Tests/HttpRedirectProcessorTests.cs
+++ b/source/Stahp/Stahp.Core.Tests/HttpRedirectProcessorTests.cs
@@ -1,0 +1,133 @@
+﻿using Moq;
+using Stahp.Core.HostTypes;
+using Stahp.Core.HttpResponseProcessing;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stahp.Core.Tests
+{
+    [TestClass]
+    public class HttpRedirectProcessorTests
+    {
+        private readonly HttpRedirectProcessor _processor;
+
+        const string RedirectUrl = "https://www.mozilla.org";
+
+        public HttpRedirectProcessorTests()
+        {
+            var hostFactoryMock = new Mock<IHostFactory>();
+            hostFactoryMock.Setup(f => f.GetHost(It.IsAny<Uri>()))
+                .Returns<Uri>(uri =>
+                {
+                    var host = new Mock<IHost>();
+
+                    host.SetupGet(h => h.HostName)
+                        .Returns(uri.Host);
+
+                    host.SetupGet(h => h.HostUrl)
+                        .Returns(uri.ToString());
+
+                    return Task.FromResult(host.Object);
+                });
+
+            _processor = new HttpRedirectProcessor(hostFactoryMock.Object);
+        }
+
+        [TestMethod]
+        [DataRow(HttpStatusCode.Continue, DisplayName = "Status Continue")]
+        [DataRow(HttpStatusCode.SwitchingProtocols, DisplayName = "Status SwitchingProtocols")]
+        [DataRow(HttpStatusCode.Processing, DisplayName = "Status Processing")]
+        [DataRow(HttpStatusCode.EarlyHints, DisplayName = "Status EarlyHints")]
+        [DataRow(HttpStatusCode.OK, DisplayName = "Status OK")]
+        [DataRow(HttpStatusCode.Created, DisplayName = "Status Created")]
+        [DataRow(HttpStatusCode.Accepted, DisplayName = "Status Accepted")]
+        [DataRow(HttpStatusCode.NonAuthoritativeInformation, DisplayName = "Status NonAuthoritativeInformation")]
+        [DataRow(HttpStatusCode.NoContent, DisplayName = "Status NoContent")]
+        [DataRow(HttpStatusCode.ResetContent, DisplayName = "Status ResetContent")]
+        [DataRow(HttpStatusCode.PartialContent, DisplayName = "Status PartialContent")]
+        [DataRow(HttpStatusCode.MultiStatus, DisplayName = "Status MultiStatus")]
+        [DataRow(HttpStatusCode.AlreadyReported, DisplayName = "Status AlreadyReported")]
+        [DataRow(HttpStatusCode.IMUsed, DisplayName = "Status IMUsed")]
+        [DataRow(HttpStatusCode.Ambiguous, DisplayName = "Status Ambiguous")]
+        [DataRow(HttpStatusCode.Unused, DisplayName = "Status Unused")]
+        [DataRow(HttpStatusCode.BadRequest, DisplayName = "Status BadRequest")]
+        [DataRow(HttpStatusCode.Unauthorized, DisplayName = "Status Unauthorized")]
+        [DataRow(HttpStatusCode.PaymentRequired, DisplayName = "Status PaymentRequired")]
+        [DataRow(HttpStatusCode.Forbidden, DisplayName = "Status Forbidden")]
+        [DataRow(HttpStatusCode.NotFound, DisplayName = "Status NotFound")]
+        [DataRow(HttpStatusCode.MethodNotAllowed, DisplayName = "Status MethodNotAllowed")]
+        [DataRow(HttpStatusCode.NotAcceptable, DisplayName = "Status NotAcceptable")]
+        [DataRow(HttpStatusCode.ProxyAuthenticationRequired, DisplayName = "Status ProxyAuthenticationRequired")]
+        [DataRow(HttpStatusCode.RequestTimeout, DisplayName = "Status RequestTimeout")]
+        [DataRow(HttpStatusCode.Conflict, DisplayName = "Status Conflict")]
+        [DataRow(HttpStatusCode.Gone, DisplayName = "Status Gone")]
+        [DataRow(HttpStatusCode.LengthRequired, DisplayName = "Status LengthRequired")]
+        [DataRow(HttpStatusCode.PreconditionFailed, DisplayName = "Status PreconditionFailed")]
+        [DataRow(HttpStatusCode.RequestEntityTooLarge, DisplayName = "Status RequestEntityTooLarge")]
+        [DataRow(HttpStatusCode.RequestUriTooLong, DisplayName = "Status RequestUriTooLong")]
+        [DataRow(HttpStatusCode.UnsupportedMediaType, DisplayName = "Status UnsupportedMediaType")]
+        [DataRow(HttpStatusCode.RequestedRangeNotSatisfiable, DisplayName = "Status RequestedRangeNotSatisfiable")]
+        [DataRow(HttpStatusCode.ExpectationFailed, DisplayName = "Status ExpectationFailed")]
+        [DataRow(HttpStatusCode.MisdirectedRequest, DisplayName = "Status MisdirectedRequest")]
+        [DataRow(HttpStatusCode.UnprocessableEntity, DisplayName = "Status UnprocessableEntity")]
+        [DataRow(HttpStatusCode.Locked, DisplayName = "Status Locked")]
+        [DataRow(HttpStatusCode.FailedDependency, DisplayName = "Status FailedDependency")]
+        [DataRow(HttpStatusCode.UpgradeRequired, DisplayName = "Status UpgradeRequired")]
+        [DataRow(HttpStatusCode.PreconditionRequired, DisplayName = "Status PreconditionRequired")]
+        [DataRow(HttpStatusCode.TooManyRequests, DisplayName = "Status TooManyRequests")]
+        [DataRow(HttpStatusCode.RequestHeaderFieldsTooLarge, DisplayName = "Status RequestHeaderFieldsTooLarge")]
+        [DataRow(HttpStatusCode.UnavailableForLegalReasons, DisplayName = "Status UnavailableForLegalReasons")]
+        [DataRow(HttpStatusCode.InternalServerError, DisplayName = "Status InternalServerError")]
+        [DataRow(HttpStatusCode.NotImplemented, DisplayName = "Status NotImplemented")]
+        [DataRow(HttpStatusCode.BadGateway, DisplayName = "Status BadGateway")]
+        [DataRow(HttpStatusCode.ServiceUnavailable, DisplayName = "Status ServiceUnavailable")]
+        [DataRow(HttpStatusCode.GatewayTimeout, DisplayName = "Status GatewayTimeout")]
+        [DataRow(HttpStatusCode.HttpVersionNotSupported, DisplayName = "Status HttpVersionNotSupported")]
+        [DataRow(HttpStatusCode.VariantAlsoNegotiates, DisplayName = "Status VariantAlsoNegotiates")]
+        [DataRow(HttpStatusCode.InsufficientStorage, DisplayName = "Status InsufficientStorage")]
+        [DataRow(HttpStatusCode.LoopDetected, DisplayName = "Status LoopDetected")]
+        [DataRow(HttpStatusCode.NotExtended, DisplayName = "Status NotExtended")]
+        [DataRow(HttpStatusCode.NetworkAuthenticationRequired, DisplayName = "Status NetworkAuthenticationRequired")]
+        public async Task Process_NotRedirectingStatusCode_ReturnsNull(HttpStatusCode httpStatusCode)
+        {
+            HttpResponseMessage responseMessage = new HttpResponseMessage(httpStatusCode)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"),
+            };
+
+            var result = await _processor.Process(responseMessage);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        [DataRow(HttpStatusCode.MovedPermanently, RedirectUrl, DisplayName = "Status MovedPermanently")]
+        [DataRow(HttpStatusCode.Found, RedirectUrl, DisplayName = "Status Found")]
+        [DataRow(HttpStatusCode.Redirect, RedirectUrl, DisplayName = "Status Redirect")]
+        [DataRow(HttpStatusCode.RedirectMethod, RedirectUrl, DisplayName = "Status RedirectMethod")]
+        [DataRow(HttpStatusCode.NotModified, RedirectUrl, DisplayName = "Status NotModified")]
+        [DataRow(HttpStatusCode.UseProxy, RedirectUrl, DisplayName = "Status UseProxy")]
+        [DataRow(HttpStatusCode.TemporaryRedirect, RedirectUrl, DisplayName = "Status TemporaryRedirect")]
+        [DataRow(HttpStatusCode.PermanentRedirect, RedirectUrl, DisplayName = "Status PermanentRedirect")]
+        public async Task Process_RedirectingStatusCode_ReturnsRedirectToUrl(HttpStatusCode httpStatusCode, string redirectTargetUrl)
+        {
+            Uri redirectTarget = new Uri(redirectTargetUrl);
+            HttpResponseMessage responseMessage = new HttpResponseMessage(httpStatusCode)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"),
+            };
+            responseMessage.Headers.Location = redirectTarget;
+
+            var traceHop = await _processor.Process(responseMessage);
+
+            Assert.IsTrue(traceHop is { RedirectType: RedirectType.Http } && traceHop.RedirectTargetUrl == redirectTarget);
+
+        }
+    }
+}

--- a/source/Stahp/Stahp.Core.Tests/HttpRedirectProcessorTests.cs
+++ b/source/Stahp/Stahp.Core.Tests/HttpRedirectProcessorTests.cs
@@ -1,14 +1,7 @@
-﻿using Moq;
-using Stahp.Core.HostTypes;
+﻿using Stahp.Core.HostTypes;
 using Stahp.Core.HttpResponseProcessing;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Stahp.Core.Tests
 {
@@ -21,22 +14,9 @@ namespace Stahp.Core.Tests
 
         public HttpRedirectProcessorTests()
         {
-            var hostFactoryMock = new Mock<IHostFactory>();
-            hostFactoryMock.Setup(f => f.GetHost(It.IsAny<Uri>()))
-                .Returns<Uri>(uri =>
-                {
-                    var host = new Mock<IHost>();
+            var hostFactoryMock = Mocks.HostFactory;
 
-                    host.SetupGet(h => h.HostName)
-                        .Returns(uri.Host);
-
-                    host.SetupGet(h => h.HostUrl)
-                        .Returns(uri.ToString());
-
-                    return Task.FromResult(host.Object);
-                });
-
-            _processor = new HttpRedirectProcessor(hostFactoryMock.Object);
+            _processor = new HttpRedirectProcessor(hostFactoryMock);
         }
 
         [TestMethod]

--- a/source/Stahp/Stahp.Core.Tests/JsRedirectProcessorTests.cs
+++ b/source/Stahp/Stahp.Core.Tests/JsRedirectProcessorTests.cs
@@ -1,8 +1,5 @@
 ﻿using AngleSharp;
 
-using Moq;
-
-using Stahp.Core.HostTypes;
 using Stahp.Core.HttpResponseProcessing;
 
 using System.Net;
@@ -174,22 +171,9 @@ namespace Stahp.Core.Tests
                 .WithJs()
                 .WithEventLoop();
 
-            var hostFactoryMock = new Mock<IHostFactory>();
-            hostFactoryMock.Setup(f => f.GetHost(It.IsAny<Uri>()))
-                .Returns<Uri>(uri =>
-                {
-                    var host = new Mock<IHost>();
+            var hostFactoryMock = Mocks.HostFactory;
 
-                    host.SetupGet(h => h.HostName)
-                        .Returns(uri.Host);
-
-                    host.SetupGet(h => h.HostUrl)
-                        .Returns(uri.ToString());
-
-                    return Task.FromResult(host.Object);
-                });
-
-            _processor = new JsRedirectProcessor(config, hostFactoryMock.Object);
+            _processor = new JsRedirectProcessor(config, hostFactoryMock);
         }
 
         [TestMethod]

--- a/source/Stahp/Stahp.Core.Tests/JsRedirectProcessorTests.cs
+++ b/source/Stahp/Stahp.Core.Tests/JsRedirectProcessorTests.cs
@@ -1,0 +1,262 @@
+﻿using AngleSharp;
+
+using Moq;
+
+using Stahp.Core.HostTypes;
+using Stahp.Core.HttpResponseProcessing;
+
+using System.Net;
+
+namespace Stahp.Core.Tests
+{
+    [TestClass]
+    public class JsRedirectProcessorTests
+    {
+        private readonly JsRedirectProcessor _processor;
+
+        const string RedirectUrl = "https://www.mozilla.org";
+
+        const string EmptyHtml = "<html></html>";
+        const string EmptyBody = "<html><body></body></html>";
+        const string SimpleHeadHrefMozilla = """
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        window.location.href = "https://www.mozilla.org";
+                    </script>
+                </head>
+            </html>
+            """;
+        const string SimpleBodyHrefMozilla = """
+            <html>
+                <body>
+                    <script type="text/javascript">
+                        window.location.href = "https://www.mozilla.org";
+                    </script>
+                </body>
+            </html>
+            """;
+
+        // legacy event handlers registered through onX
+        const string Document_LegacyEvent_ReadyStateComplete_Function_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        document.onreadystatechange = function() {
+                            if (document.readyState == "complete")
+                                window.location.href = "{{RedirectUrl}}";
+                        };
+                    </script>
+                </head>
+            </html>
+            """;
+        const string Window_LegacyEvent_Load_Function_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        window.onload = function() {
+                            window.location.href = "{{RedirectUrl}}";
+                        };
+                    </script>
+                </head>
+            </html>
+            """;
+        const string Window_LegacyEvent_PageShow_Function_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        window.onpageshow = function() {
+                            window.location.href = "{{RedirectUrl}}";
+                        };
+                    </script>
+                </head>
+            </html>
+            """;
+
+        // event handlers registered through addEventListener(, function() { })
+        const string Document_EventListener_DomContentLoaded_Function_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        document.addEventListener("DOMContentLoaded", function() {
+                            window.location.href = "{{RedirectUrl}}";
+                        });
+                    </script>
+                </head>
+            </html>
+            """;
+        const string Document_EventListener_ReadyStateComplete_Function_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        document.addEventListener("readystatechange", function() {
+                            if (document.readyState == "complete")
+                                window.location.href = "{{RedirectUrl}}";
+                        });
+                    </script>
+                </head>
+            </html>
+            """;
+        const string Window_EventListener_Load_Function_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        window.addEventListener("load", function() {
+                            window.location.href = "{{RedirectUrl}}";
+                        });
+                    </script>
+                </head>
+            </html>
+            """;
+        const string Window_EventListener_PageShow_Function_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        window.addEventListener("pageshow", function() {
+                            window.location.href = "{{RedirectUrl}}";
+                        });
+                    </script>
+                </head>
+            </html>
+            """;
+
+        // event handlers registered through addEventListener(, (event) => { })
+        // not supported by AngleSharp.Js v0.15.0, as it's Jint dependency only implements ECMA 5.1
+        const string Document_EventListener_DomContentLoaded_Arrow_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        document.addEventListener("DOMContentLoaded", (event) => {
+                            window.location.href = "{{RedirectUrl}}";
+                        });
+                    </script>
+                </head>
+            </html>
+            """;
+        const string Document_EventListener_ReadyStateComplete_Arrow_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        document.addEventListener("readystatechange", (event) => {
+                            if (document.readyState == "complete")
+                                window.location.href = "{{RedirectUrl}}";
+                        });
+                    </script>
+                </head>
+            </html>
+            """;
+        const string Window_EventListener_Load_Arrow_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        window.addEventListener("load", (event) => {
+                            window.location.href = "{{RedirectUrl}}";
+                        });
+                    </script>
+                </head>
+            </html>
+            """;
+        const string Window_EventListener_PageShow_Arrow_HrefMozilla = $$"""
+            <html>
+                <head>
+                    <script type="text/javascript">
+                        window.addEventListener("pageshow", (event) => {
+                            window.location.href = "{{RedirectUrl}}";
+                        });
+                    </script>
+                </head>
+            </html>
+            """;
+
+        public JsRedirectProcessorTests()
+        {
+            IConfiguration config = Configuration.Default
+                .WithJs()
+                .WithEventLoop();
+
+            var hostFactoryMock = new Mock<IHostFactory>();
+            hostFactoryMock.Setup(f => f.GetHost(It.IsAny<Uri>()))
+                .Returns<Uri>(uri =>
+                {
+                    var host = new Mock<IHost>();
+
+                    host.SetupGet(h => h.HostName)
+                        .Returns(uri.Host);
+
+                    host.SetupGet(h => h.HostUrl)
+                        .Returns(uri.ToString());
+
+                    return Task.FromResult(host.Object);
+                });
+
+            _processor = new JsRedirectProcessor(config, hostFactoryMock.Object);
+        }
+
+        [TestMethod]
+        [DataRow("", DisplayName = "Empty String")]
+        [DataRow(EmptyHtml, DisplayName = nameof(EmptyHtml))]
+        [DataRow(EmptyBody, DisplayName = nameof(EmptyBody))]
+        public async Task Process_NoScriptTags_ReturnsNull(string responseBody)
+        {
+            HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"),
+                Content = new StringContent(responseBody)
+            };
+
+            var result = await _processor.Process(responseMessage);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        [DataRow(SimpleHeadHrefMozilla, RedirectUrl, DisplayName = nameof(SimpleHeadHrefMozilla))]
+        [DataRow(SimpleBodyHrefMozilla, RedirectUrl, DisplayName = nameof(SimpleBodyHrefMozilla))]
+        public async Task Process_RedirectingScriptTags_ReturnsRedirectToUrl(string responseBody, string expectedRedirectTargetUrl)
+        {
+            HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"),
+                Content = new StringContent(responseBody)
+            };
+
+            Uri expectedRedirectTarget = new Uri(expectedRedirectTargetUrl);
+
+            var traceHop = await _processor.Process(responseMessage);
+
+            Assert.IsTrue(traceHop is { RedirectType: RedirectType.JsHref } && traceHop.RedirectTargetUrl == expectedRedirectTarget);
+        }
+
+        [TestMethod]
+        // disabled due to known issue, waiting for AngleSharp.Js fix or upgrade to use Jint v3
+        //[DataRow(Document_LegacyEvent_ReadyStateComplete_Function_HrefMozilla, RedirectUrl, DisplayName = nameof(Document_LegacyEvent_ReadyStateComplete_Function_HrefMozilla))]
+        [DataRow(Window_LegacyEvent_Load_Function_HrefMozilla, RedirectUrl, DisplayName = nameof(Window_LegacyEvent_Load_Function_HrefMozilla))]
+        [DataRow(Window_LegacyEvent_PageShow_Function_HrefMozilla, RedirectUrl, DisplayName = nameof(Window_LegacyEvent_PageShow_Function_HrefMozilla))]
+        
+        [DataRow(Document_EventListener_DomContentLoaded_Function_HrefMozilla, RedirectUrl, DisplayName = nameof(Document_EventListener_DomContentLoaded_Function_HrefMozilla))]
+        // disabled due to known issues, waiting for AngleSharp.Js to use Jint v3
+        //[DataRow(Document_EventListener_ReadyStateComplete_Function_HrefMozilla, RedirectUrl, DisplayName = nameof(Document_EventListener_ReadyStateComplete_Function_HrefMozilla))]
+        [DataRow(Window_EventListener_Load_Function_HrefMozilla, RedirectUrl, DisplayName = nameof(Window_EventListener_Load_Function_HrefMozilla))]
+        [DataRow(Window_EventListener_PageShow_Function_HrefMozilla, RedirectUrl, DisplayName = nameof(Window_EventListener_PageShow_Function_HrefMozilla))]
+
+        // arrow function tests disabled due to known issues, waiting for AngleSharp.Js to use Jint v3
+        //[DataRow(Document_EventListener_DomContentLoaded_Arrow_HrefMozilla, RedirectUrl, DisplayName = nameof(Document_EventListener_DomContentLoaded_Arrow_HrefMozilla))]
+        //[DataRow(Document_EventListener_ReadyStateComplete_Arrow_HrefMozilla, RedirectUrl, DisplayName = nameof(Document_EventListener_ReadyStateComplete_Arrow_HrefMozilla))]
+        //[DataRow(Window_EventListener_Load_Arrow_HrefMozilla, RedirectUrl, DisplayName = nameof(Window_EventListener_Load_Arrow_HrefMozilla))]
+        //[DataRow(Window_EventListener_PageShow_Arrow_HrefMozilla, RedirectUrl, DisplayName = nameof(Window_EventListener_PageShow_Arrow_HrefMozilla))]
+        public async Task Process_OnEventRedirectScriptTags_ReturnsRedirectToUrl(string responseBody, string expectedRedirectTargetUrl)
+        {
+            HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"),
+                Content = new StringContent(responseBody)
+            };
+
+            Uri expectedRedirectTarget = new Uri(expectedRedirectTargetUrl);
+
+            var traceHop = await _processor.Process(responseMessage);
+
+            Assert.IsTrue(traceHop is { RedirectType: RedirectType.JsHref } && traceHop.RedirectTargetUrl == expectedRedirectTarget);
+        }
+    }
+}

--- a/source/Stahp/Stahp.Core.Tests/Mocks.cs
+++ b/source/Stahp/Stahp.Core.Tests/Mocks.cs
@@ -1,0 +1,40 @@
+﻿using NSubstitute;
+
+using Stahp.Core.HostTypes;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stahp.Core.Tests
+{
+    internal static class Mocks
+    {
+        private static IHostFactory? _hostFactory;
+
+        internal static IHostFactory HostFactory
+        {
+            get
+            {
+                if (_hostFactory is null)
+                {
+                    _hostFactory = Substitute.For<IHostFactory>();
+                    _hostFactory.GetHost(Arg.Any<Uri>())
+                        .Returns(callInfo =>
+                        {
+                            var host = Substitute.For<IHost>();
+
+                            host.HostName.Returns(callInfo.Arg<Uri>().Host);
+
+                            host.HostUrl.Returns(callInfo.Arg<Uri>().ToString());
+
+                            return Task.FromResult(host);
+                        });
+                }
+                return _hostFactory;
+            }
+        }
+    }
+}

--- a/source/Stahp/Stahp.Core.Tests/Stahp.Core.Tests.csproj
+++ b/source/Stahp/Stahp.Core.Tests/Stahp.Core.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+	<PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stahp.Core\Stahp.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/source/Stahp/Stahp.Core.Tests/Stahp.Core.Tests.csproj
+++ b/source/Stahp/Stahp.Core.Tests/Stahp.Core.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Stahp/Stahp.Core.Tests/Usings.cs
+++ b/source/Stahp/Stahp.Core.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/source/Stahp/Stahp.Core/ExceptionProcessing/DefaultExceptionProcessor.cs
+++ b/source/Stahp/Stahp.Core/ExceptionProcessing/DefaultExceptionProcessor.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Stahp.Core.ExceptionProcessing
+﻿namespace Stahp.Core.ExceptionProcessing
 {
     internal class DefaultExceptionProcessor : ExceptionProcessorBase, IExceptionProcessor
     {

--- a/source/Stahp/Stahp.Core/ExceptionProcessing/ExceptionProcessorBase.cs
+++ b/source/Stahp/Stahp.Core/ExceptionProcessing/ExceptionProcessorBase.cs
@@ -1,11 +1,4 @@
-﻿
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Stahp.Core.ExceptionProcessing
+﻿namespace Stahp.Core.ExceptionProcessing
 {
     internal abstract class ExceptionProcessorBase : IExceptionProcessor
     {

--- a/source/Stahp/Stahp.Core/ExceptionProcessing/NoSuchHostProcessor.cs
+++ b/source/Stahp/Stahp.Core/ExceptionProcessing/NoSuchHostProcessor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Net.Sockets;
 
 namespace Stahp.Core.ExceptionProcessing
 {

--- a/source/Stahp/Stahp.Core/Extensions/IServiceCollectionExtensions.cs
+++ b/source/Stahp/Stahp.Core/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using AngleSharp;
+
+using Microsoft.Extensions.DependencyInjection;
 
 using Stahp.Core.ExceptionProcessing;
 using Stahp.Core.HostTypes;
@@ -18,18 +20,28 @@ namespace Stahp.Core
                 {
                     AllowAutoRedirect = false
                 });
+
             return services
                 .AddMemoryCache()
                 .AddTransient<IHostFactory, HostFactory>()
+                .AddAngleSharp()
                 .AddHttpResponseProcessors()
                 .AddExceptionProcessors()
                 .AddTransient(_ => new WhoisLookup())
                 .AddTransient<IRequestTracer, RequestTracer>();
         }
 
+        private static IServiceCollection AddAngleSharp(this IServiceCollection services)
+        {
+            return services.AddSingleton(Configuration.Default
+                .WithJs()
+                .WithDefaultLoader());
+        }
+
         private static IServiceCollection AddHttpResponseProcessors(this IServiceCollection services)
         {
             return services
+                .AddTransient<IHttpResponseProcessor, JsRedirectProcessor>()
                 .AddTransient<IHttpResponseProcessor, HtmlRedirectProcessor>()
                 .AddTransient<IHttpResponseProcessor, HttpRedirectProcessor>()
                 // DefaultHttpResponseProcessor must be added last, as its CanProcess() will always return true

--- a/source/Stahp/Stahp.Core/Extensions/IServiceCollectionExtensions.cs
+++ b/source/Stahp/Stahp.Core/Extensions/IServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Stahp.Core.ExceptionProcessing;
 using Stahp.Core.HostTypes;
 using Stahp.Core.HttpResponseProcessing;
+using Stahp.Core.HttpResponseProcessing.Pipeline;
 
 using Whois;
 
@@ -15,7 +16,7 @@ namespace Stahp.Core
         public static IServiceCollection AddStahpCore(this IServiceCollection services)
         {
             services
-                .AddHttpClient<RequestTracer>()
+                .AddHttpClient<IRequestTracer, RequestTracer>()
                 .ConfigurePrimaryHttpMessageHandler(_ => new HttpClientHandler()
                 {
                     AllowAutoRedirect = false
@@ -27,25 +28,43 @@ namespace Stahp.Core
                 .AddAngleSharp()
                 .AddHttpResponseProcessors()
                 .AddExceptionProcessors()
-                .AddTransient(_ => new WhoisLookup())
-                .AddTransient<IRequestTracer, RequestTracer>();
+                .AddTransient(_ => new WhoisLookup());
         }
 
         private static IServiceCollection AddAngleSharp(this IServiceCollection services)
         {
             return services.AddSingleton(Configuration.Default
                 .WithJs()
+                .WithEventLoop()
                 .WithDefaultLoader());
         }
 
         private static IServiceCollection AddHttpResponseProcessors(this IServiceCollection services)
         {
+            // each IHttpResponseProcessor implementation must be
+            // - registered in DI
+            // - have an action to resolve added to PipelineOptions
+            //   - the default processor should be set on PrimaryProcessor
+            //   - all others should be added as DelegatingProcessors
+            // a pipeline factory will take IServiceProvider and the PipelineOptions
+            // RequestTracer takes the pipeline factory, and asks it to build and return the pipeline
+
+            services.Configure<PipelineOptions>(options =>
+            {
+                options.BuilderActions.Add(b => b.PrimaryProcessor = b.Services.GetRequiredService<DefaultHttpResponseProcessor>());
+                // add in the order they should be run
+                options.BuilderActions.Add(b => b.DelegatingProcessors.Add(b.Services.GetRequiredService<JsRedirectProcessor>()));
+                options.BuilderActions.Add(b => b.DelegatingProcessors.Add(b.Services.GetRequiredService<HtmlRedirectProcessor>()));
+                options.BuilderActions.Add(b => b.DelegatingProcessors.Add(b.Services.GetRequiredService<HttpRedirectProcessor>()));
+            });
+
             return services
-                .AddTransient<IHttpResponseProcessor, JsRedirectProcessor>()
-                .AddTransient<IHttpResponseProcessor, HtmlRedirectProcessor>()
-                .AddTransient<IHttpResponseProcessor, HttpRedirectProcessor>()
-                // DefaultHttpResponseProcessor must be added last, as its CanProcess() will always return true
-                .AddTransient<IHttpResponseProcessor, DefaultHttpResponseProcessor>();
+                .AddTransient<JsRedirectProcessor>()
+                .AddTransient<HtmlRedirectProcessor>()
+                .AddTransient<HttpRedirectProcessor>()
+                .AddTransient<DefaultHttpResponseProcessor>()
+                .AddTransient<HttpResponseProcessorBuilder>()
+                .AddSingleton<HttpResponseProcessorPipelineFactory>();
         }
 
         private static IServiceCollection AddExceptionProcessors(this IServiceCollection services)

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/DefaultHttpResponseProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/DefaultHttpResponseProcessor.cs
@@ -1,14 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-
-using Stahp.Core.HostTypes;
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Whois;
+﻿using Stahp.Core.HostTypes;
 
 namespace Stahp.Core.HttpResponseProcessing
 {
@@ -18,12 +8,7 @@ namespace Stahp.Core.HttpResponseProcessing
         {
         }
 
-        public override Task<bool> CanProcess(HttpResponseMessage httpResponseMessage)
-        {
-            return Task.FromResult(true);
-        }
-
-        public override async Task<TraceHop> Process(HttpResponseMessage httpResponseMessage)
+        public override async Task<TraceHop?> Process(HttpResponseMessage httpResponseMessage)
         {
             return new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
             {

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/DelegatingHttpResponseProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/DelegatingHttpResponseProcessor.cs
@@ -1,0 +1,20 @@
+﻿using Stahp.Core.HostTypes;
+
+namespace Stahp.Core.HttpResponseProcessing
+{
+    internal abstract class DelegatingHttpResponseProcessor : HttpResponseProcessorBase, IHttpResponseProcessor
+    {
+        public IHttpResponseProcessor? InnerProcessor { get; set; }
+
+        protected DelegatingHttpResponseProcessor(IHostFactory hostFactory) : base(hostFactory)
+        {
+        }
+
+        public override async Task<TraceHop?> Process(HttpResponseMessage httpResponseMessage)
+        {
+            return InnerProcessor is not null 
+                ? await InnerProcessor.Process(httpResponseMessage)
+                : null;
+        }
+    }
+}

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/HtmlRedirectProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/HtmlRedirectProcessor.cs
@@ -1,81 +1,58 @@
 ﻿using AngleSharp;
 using AngleSharp.Dom;
-
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
+using AngleSharp.Html.Dom;
 
 using Stahp.Core.HostTypes;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-
-using Whois;
 
 namespace Stahp.Core.HttpResponseProcessing
 {
-    internal class HtmlRedirectProcessor : HttpResponseProcessorBase, IHttpResponseProcessor
+    internal class HtmlRedirectProcessor : DelegatingHttpResponseProcessor, IHttpResponseProcessor
     {
-        private readonly IMemoryCache _memoryCache;
         private readonly IConfiguration _anglesharpConfig;
-        private static readonly MemoryCacheEntryOptions _cacheEntryOptions = new()
-        {
-            SlidingExpiration = TimeSpan.FromMinutes(10)
-        };
 
-        public HtmlRedirectProcessor(IMemoryCache memoryCache, IConfiguration anglesharpConfig, IHostFactory hostFactory) : base(hostFactory)
+        public HtmlRedirectProcessor(IConfiguration anglesharpConfig, IHostFactory hostFactory) : base(hostFactory)
         {
-            _memoryCache = memoryCache;
             _anglesharpConfig = anglesharpConfig;
         }
 
-        private static string GetCacheKey(HttpResponseMessage responseMessage) => $"{nameof(HtmlRedirectProcessor)}_{responseMessage.RequestMessage!.RequestUri}";
-
-        public override async Task<bool> CanProcess(HttpResponseMessage httpResponseMessage)
+        private async Task<IHtmlMetaElement?> GetRefreshTagFromHttpResponse(HttpResponseMessage httpResponseMessage)
         {
-            if (httpResponseMessage.StatusCode != HttpStatusCode.OK)
-                return false;
-
-            // we've either hit the final destination, or
-            // the page will redirect via
-            //  - a HTML Meta Refresh tag (this IHttpResponseProcessor), or
-            //  - setting the JavaScript window.location property (JsRedirectProcessor)
-            IDocument htmlDoc = await BrowsingContext.New(_anglesharpConfig).OpenAsync(async req => 
+            IDocument htmlDoc = await BrowsingContext.New(_anglesharpConfig).OpenAsync(async req =>
                 req.Content(await httpResponseMessage.Content.ReadAsStreamAsync()));
 
             // see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv
             // content attribute format matches "[seconds]; url=[address]" (space between ";" and "url=" is optional
-            IElement? refreshTag = htmlDoc.Head
-                ?.QuerySelectorAll("meta")
+            IHtmlMetaElement? refreshTag = htmlDoc.Head
+                ?.GetNodes<IHtmlMetaElement>()
                 ?.FirstOrDefault(node =>
-                    string.Equals(node.GetAttribute("http-equiv"), "refresh", StringComparison.OrdinalIgnoreCase) &&
-                    node.GetAttribute("content")?.Contains("url=", StringComparison.OrdinalIgnoreCase) == false);
-
-            if (refreshTag is not null)
-            {
-                _memoryCache.Set(GetCacheKey(httpResponseMessage), refreshTag, _cacheEntryOptions);
-            }
-            return refreshTag is not null;
+                    string.Equals(node.HttpEquivalent, "refresh", StringComparison.OrdinalIgnoreCase) &&
+                    node.Content?.Contains("url=", StringComparison.OrdinalIgnoreCase) == true);
+            return refreshTag;
         }
 
-        public override async Task<TraceHop> Process(HttpResponseMessage httpResponseMessage)
+        public override async Task<TraceHop?> Process(HttpResponseMessage httpResponseMessage)
         {
-            IElement refreshTag = _memoryCache.Get<IElement>(GetCacheKey(httpResponseMessage))!;
-
-            string refreshTagContent = refreshTag.GetAttribute("content")!;
-
-            string redirectTarget = refreshTagContent![(refreshTagContent.IndexOf("url=", StringComparison.OrdinalIgnoreCase) + 4)..];
-
-            return new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
+            if (httpResponseMessage.StatusCode == HttpStatusCode.OK)
             {
-                RedirectType = RedirectType.HtmlMeta,
-                RedirectTargetUrl = new Uri(redirectTarget),
-                DomainHost = await DetermineHost(httpResponseMessage.RequestMessage!.RequestUri!),
-                WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage!.RequestUri!),
-            };
+                IHtmlMetaElement? refreshTag = await GetRefreshTagFromHttpResponse(httpResponseMessage);
+
+                if (refreshTag is not null)
+                {
+                    string redirectTarget = refreshTag.Content![(refreshTag.Content!.IndexOf("url=", StringComparison.OrdinalIgnoreCase) + 4)..];
+
+                    return new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
+                    {
+                        RedirectType = RedirectType.HtmlMeta,
+                        RedirectTargetUrl = new Uri(redirectTarget),
+                        DomainHost = await DetermineHost(httpResponseMessage.RequestMessage!.RequestUri!),
+                        WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage!.RequestUri!),
+                    };
+                }
+            }
+
+            return await base.Process(httpResponseMessage);
         }
     }
 }

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/HttpRedirectProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/HttpRedirectProcessor.cs
@@ -29,10 +29,9 @@ namespace Stahp.Core.HttpResponseProcessing
         {
             return new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
             {
-                Redirects = true,
                 RedirectTargetUrl = httpResponseMessage.Headers.Location,
-                DomainHost = await DetermineHost(httpResponseMessage.RequestMessage.RequestUri),
-                WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage.RequestUri),
+                DomainHost = await DetermineHost(httpResponseMessage.RequestMessage.RequestUri!),
+                WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage.RequestUri!),
             };
         }
     }

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/HttpRedirectProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/HttpRedirectProcessor.cs
@@ -1,38 +1,27 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Stahp.Core.HostTypes;
 
-using Stahp.Core.HostTypes;
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-
-using Whois;
 
 namespace Stahp.Core.HttpResponseProcessing
 {
-    internal class HttpRedirectProcessor : HttpResponseProcessorBase, IHttpResponseProcessor
+    internal class HttpRedirectProcessor : DelegatingHttpResponseProcessor, IHttpResponseProcessor
     {
         public HttpRedirectProcessor(IHostFactory hostFactory) : base(hostFactory)
         {
         }
 
-        public override Task<bool> CanProcess(HttpResponseMessage httpResponseMessage)
+        public override async Task<TraceHop?> Process(HttpResponseMessage httpResponseMessage)
         {
-            return Task.FromResult(httpResponseMessage.StatusCode >= HttpStatusCode.MovedPermanently 
-                && httpResponseMessage.StatusCode <= HttpStatusCode.PermanentRedirect);
-        }
-
-        public override async Task<TraceHop> Process(HttpResponseMessage httpResponseMessage)
-        {
-            return new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
+            return httpResponseMessage.StatusCode switch
             {
-                RedirectTargetUrl = httpResponseMessage.Headers.Location,
-                DomainHost = await DetermineHost(httpResponseMessage.RequestMessage.RequestUri!),
-                WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage.RequestUri!),
-            };
+                >= HttpStatusCode.MovedPermanently and <= HttpStatusCode.PermanentRedirect => new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
+                {
+                    RedirectTargetUrl = httpResponseMessage.Headers.Location,
+                    DomainHost = await DetermineHost(httpResponseMessage.RequestMessage.RequestUri!),
+                    WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage.RequestUri!),
+                },
+                _ => await base.Process(httpResponseMessage)
+            }; ;
         }
     }
 }

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/HttpRedirectProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/HttpRedirectProcessor.cs
@@ -14,7 +14,9 @@ namespace Stahp.Core.HttpResponseProcessing
         {
             return httpResponseMessage.StatusCode switch
             {
-                >= HttpStatusCode.MovedPermanently and <= HttpStatusCode.PermanentRedirect => new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
+                >= HttpStatusCode.MovedPermanently and 
+                <= HttpStatusCode.PermanentRedirect and 
+                not HttpStatusCode.Unused => new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
                 {
                     RedirectTargetUrl = httpResponseMessage.Headers.Location,
                     DomainHost = await DetermineHost(httpResponseMessage.RequestMessage.RequestUri!),

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/HttpResponseProcessorBase.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/HttpResponseProcessorBase.cs
@@ -17,8 +17,7 @@ namespace Stahp.Core.HttpResponseProcessing
             _hostFactory = hostFactory;
         }
 
-        public abstract Task<bool> CanProcess(HttpResponseMessage httpResponseMessage);
-        public abstract Task<TraceHop> Process(HttpResponseMessage httpResponseMessage);
+        public abstract Task<TraceHop?> Process(HttpResponseMessage httpResponseMessage);
 
         protected async Task<IHost> DetermineHost(Uri requestUri)
         {

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/IHttpResponseProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/IHttpResponseProcessor.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Stahp.Core.HttpResponseProcessing
+﻿namespace Stahp.Core.HttpResponseProcessing
 {
     public interface IHttpResponseProcessor
     {
-        Task<bool> CanProcess(HttpResponseMessage httpResponseMessage);
-
-        Task<TraceHop> Process(HttpResponseMessage httpResponseMessage);
+        Task<TraceHop?> Process(HttpResponseMessage httpResponseMessage);
     }
 }

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/JsRedirectProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/JsRedirectProcessor.cs
@@ -1,0 +1,64 @@
+﻿using AngleSharp;
+using AngleSharp.Dom;
+
+using Microsoft.Extensions.Caching.Memory;
+
+using Stahp.Core.HostTypes;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stahp.Core.HttpResponseProcessing
+{
+    internal class JsRedirectProcessor : HttpResponseProcessorBase, IHttpResponseProcessor
+    {
+        private readonly IMemoryCache _memoryCache;
+        private readonly IConfiguration _anglesharpConfig;
+        private static readonly MemoryCacheEntryOptions _cacheEntryOptions = new()
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(10)
+        };
+
+        public JsRedirectProcessor(IMemoryCache memoryCache, IConfiguration anglesharpConfig, IHostFactory hostFactory) : base(hostFactory)
+        {
+            _memoryCache = memoryCache;
+            _anglesharpConfig = anglesharpConfig;
+        }
+
+        private static string GetCacheKey(HttpResponseMessage responseMessage) => $"{nameof(JsRedirectProcessor)}_{responseMessage.RequestMessage!.RequestUri}";
+
+        public override async Task<bool> CanProcess(HttpResponseMessage httpResponseMessage)
+        {
+            if (httpResponseMessage.StatusCode != System.Net.HttpStatusCode.OK)
+                return false;
+
+            IDocument htmlDoc = await BrowsingContext.New(_anglesharpConfig)
+                .OpenAsync(async req => req.Content(await httpResponseMessage.Content.ReadAsStreamAsync()));
+
+            Uri currentUri = new(htmlDoc.DocumentUri);
+
+            if (!currentUri.Host.Equals(httpResponseMessage.RequestMessage!.RequestUri!.Host))
+            {
+                _memoryCache.Set(GetCacheKey(httpResponseMessage), currentUri, _cacheEntryOptions);
+                return true;
+            }
+            return false;
+        }
+
+        public override async Task<TraceHop> Process(HttpResponseMessage httpResponseMessage)
+        {
+            Uri newUri = _memoryCache.Get<Uri>(GetCacheKey(httpResponseMessage))!;
+
+            return new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
+            {
+                RedirectType = RedirectType.JsHref,
+                RedirectTargetUrl = newUri,
+                DomainHost = await DetermineHost(httpResponseMessage.RequestMessage!.RequestUri!),
+                WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage!.RequestUri!),
+            };
+        }
+    }
+}

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/JsRedirectProcessor.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/JsRedirectProcessor.cs
@@ -1,64 +1,40 @@
 ﻿using AngleSharp;
 using AngleSharp.Dom;
 
-using Microsoft.Extensions.Caching.Memory;
-
 using Stahp.Core.HostTypes;
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Stahp.Core.HttpResponseProcessing
 {
-    internal class JsRedirectProcessor : HttpResponseProcessorBase, IHttpResponseProcessor
+    internal class JsRedirectProcessor : DelegatingHttpResponseProcessor, IHttpResponseProcessor
     {
-        private readonly IMemoryCache _memoryCache;
         private readonly IConfiguration _anglesharpConfig;
-        private static readonly MemoryCacheEntryOptions _cacheEntryOptions = new()
-        {
-            SlidingExpiration = TimeSpan.FromMinutes(10)
-        };
 
-        public JsRedirectProcessor(IMemoryCache memoryCache, IConfiguration anglesharpConfig, IHostFactory hostFactory) : base(hostFactory)
+        public JsRedirectProcessor(IConfiguration anglesharpConfig, IHostFactory hostFactory) : base(hostFactory)
         {
-            _memoryCache = memoryCache;
             _anglesharpConfig = anglesharpConfig;
         }
 
-        private static string GetCacheKey(HttpResponseMessage responseMessage) => $"{nameof(JsRedirectProcessor)}_{responseMessage.RequestMessage!.RequestUri}";
-
-        public override async Task<bool> CanProcess(HttpResponseMessage httpResponseMessage)
+        public override async Task<TraceHop?> Process(HttpResponseMessage httpResponseMessage)
         {
-            if (httpResponseMessage.StatusCode != System.Net.HttpStatusCode.OK)
-                return false;
-
-            IDocument htmlDoc = await BrowsingContext.New(_anglesharpConfig)
-                .OpenAsync(async req => req.Content(await httpResponseMessage.Content.ReadAsStreamAsync()));
-
-            Uri currentUri = new(htmlDoc.DocumentUri);
-
-            if (!currentUri.Host.Equals(httpResponseMessage.RequestMessage!.RequestUri!.Host))
+            if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                _memoryCache.Set(GetCacheKey(httpResponseMessage), currentUri, _cacheEntryOptions);
-                return true;
+                using IBrowsingContext browsingContext = BrowsingContext.New(_anglesharpConfig);
+
+                using IDocument htmlDoc = await browsingContext
+                    .OpenAsync(async req => req.Content(await httpResponseMessage.Content.ReadAsStreamAsync()))
+                    .WhenStable();
+
+                if (!new Uri(htmlDoc.DocumentUri).Host.Equals(httpResponseMessage.RequestMessage!.RequestUri!.Host))
+                    return new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
+                    {
+                        RedirectType = RedirectType.JsHref,
+                        RedirectTargetUrl = new Uri(htmlDoc.DocumentUri),
+                        DomainHost = await DetermineHost(httpResponseMessage.RequestMessage!.RequestUri!),
+                        WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage!.RequestUri!),
+                    };
             }
-            return false;
-        }
 
-        public override async Task<TraceHop> Process(HttpResponseMessage httpResponseMessage)
-        {
-            Uri newUri = _memoryCache.Get<Uri>(GetCacheKey(httpResponseMessage))!;
-
-            return new TraceHop(httpResponseMessage.RequestMessage!.RequestUri!, httpResponseMessage.StatusCode)
-            {
-                RedirectType = RedirectType.JsHref,
-                RedirectTargetUrl = newUri,
-                DomainHost = await DetermineHost(httpResponseMessage.RequestMessage!.RequestUri!),
-                WebHost = await DetermineWebHost(httpResponseMessage.RequestMessage!.RequestUri!),
-            };
+            return await base.Process(httpResponseMessage);
         }
     }
 }

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/Pipeline/HttpResponseProcessorBuilder.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/Pipeline/HttpResponseProcessorBuilder.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stahp.Core.HttpResponseProcessing.Pipeline
+{
+    internal class HttpResponseProcessorBuilder
+    {
+        public IServiceProvider Services { get; }
+
+        public IHttpResponseProcessor? PrimaryProcessor { get; set; }
+        public IList<DelegatingHttpResponseProcessor> DelegatingProcessors { get; } = new List<DelegatingHttpResponseProcessor>();
+
+        public HttpResponseProcessorBuilder(IServiceProvider serviceProvider)
+        {
+            Services = serviceProvider;
+        }
+
+        public IHttpResponseProcessor Build()
+        {
+            if (PrimaryProcessor is null)
+                throw new InvalidOperationException("PrimaryProcessor is null");
+
+            IHttpResponseProcessor next = PrimaryProcessor;
+
+            // order in the list should be the order they are to be run
+            // so we need to set up the delegation in the reverse order
+            for (int i = DelegatingProcessors.Count - 1; i >= 0; i--)
+            {
+                DelegatingHttpResponseProcessor? processor = DelegatingProcessors[i];
+                
+                if (processor is null)
+                    throw new InvalidOperationException("Additional processor is null.");
+
+                processor.InnerProcessor = next;
+                next = processor;
+            }
+
+            return next;
+        }
+    }
+}

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/Pipeline/HttpResponseProcessorPipelineFactory.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/Pipeline/HttpResponseProcessorPipelineFactory.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stahp.Core.HttpResponseProcessing.Pipeline
+{
+    internal class HttpResponseProcessorPipelineFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IOptionsMonitor<PipelineOptions> _optionsMonitor;
+
+        public HttpResponseProcessorPipelineFactory(IServiceProvider serviceProvider, IOptionsMonitor<PipelineOptions> optionsMonitor)
+        {
+            _serviceProvider = serviceProvider;
+            _optionsMonitor = optionsMonitor;
+        }
+
+        public IHttpResponseProcessor Create()
+        {
+            var options = _optionsMonitor.CurrentValue;
+            var builder = _serviceProvider.GetRequiredService<HttpResponseProcessorBuilder>();
+
+            foreach (var configure in options.BuilderActions)
+            {
+                configure(builder);
+            }
+
+            return builder.Build();
+        }
+    }
+}

--- a/source/Stahp/Stahp.Core/HttpResponseProcessing/Pipeline/PipelineOptions.cs
+++ b/source/Stahp/Stahp.Core/HttpResponseProcessing/Pipeline/PipelineOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace Stahp.Core.HttpResponseProcessing.Pipeline
+{
+    internal class PipelineOptions
+    {
+        public IList<Action<HttpResponseProcessorBuilder>> BuilderActions { get; } = new List<Action<HttpResponseProcessorBuilder>>();
+    }
+}

--- a/source/Stahp/Stahp.Core/RedirectType.cs
+++ b/source/Stahp/Stahp.Core/RedirectType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stahp.Core
+{
+    public enum RedirectType
+    {
+        None,
+        Http,
+        HtmlMeta,
+        JsHref
+    }
+}

--- a/source/Stahp/Stahp.Core/RequestTracer.cs
+++ b/source/Stahp/Stahp.Core/RequestTracer.cs
@@ -2,27 +2,22 @@
 using Microsoft.Extensions.Logging;
 
 using Stahp.Core.ExceptionProcessing;
-using Stahp.Core.HttpResponseProcessing;
-
-using System.Net.Sockets;
+using Stahp.Core.HttpResponseProcessing.Pipeline;
 
 namespace Stahp.Core
 {
-    public class RequestTracer : IRequestTracer
+    internal class RequestTracer : IRequestTracer
     {
         private readonly HttpClient _httpClient;
-        private readonly IEnumerable<IHttpResponseProcessor> _httpResponseProcessors;
+        private readonly HttpResponseProcessorPipelineFactory _pipelineFactory;
         private readonly IEnumerable<IExceptionProcessor> _exceptionProcessors;
         private readonly ILogger<RequestTracer> _logger;
 
-        public RequestTracer(IEnumerable<IHttpResponseProcessor> httpResponseProcessors, IEnumerable<IExceptionProcessor> exceptionProcessors, IHttpClientFactory httpClientFactory, ILogger<RequestTracer> logger)
+        public RequestTracer(HttpResponseProcessorPipelineFactory pipelineFactory, IEnumerable<IExceptionProcessor> exceptionProcessors, HttpClient httpClient, ILogger<RequestTracer> logger)
         {
-            // the resolved HttpClient when registered as a typed client doesn't seem to obey the primary http client handler configuration
-            //  when using constructor injection
-            // retrieving via IHttpClientFactory does work though
-            _httpClient = httpClientFactory.CreateClient(nameof(RequestTracer));
-            _httpResponseProcessors = httpResponseProcessors;
+            _pipelineFactory = pipelineFactory;
             _exceptionProcessors = exceptionProcessors;
+            _httpClient = httpClient;
             _logger = logger;
         }
 
@@ -32,7 +27,13 @@ namespace Stahp.Core
             Uri nextUrl = url;
             do
             {
-                TraceHop hop = await GetNextHop(nextUrl);
+                TraceHop? hop = await GetNextHop(nextUrl);
+
+                if (hop is null)
+                {
+                    reachedEnd = true;
+                    continue;
+                }
 
                 yield return hop;
 
@@ -47,7 +48,7 @@ namespace Stahp.Core
             } while (!reachedEnd);
         }
 
-        private async Task<TraceHop> GetNextHop(Uri url)
+        private async Task<TraceHop?> GetNextHop(Uri url)
         {
             HttpRequestMessage request = new(HttpMethod.Get, url);
             try
@@ -55,13 +56,8 @@ namespace Stahp.Core
                 _logger.LogInformation("Starting trace for {url}", url);
                 HttpResponseMessage response = await _httpClient.SendAsync(request);
 
-                foreach (var processor in _httpResponseProcessors)
-                {
-                    if (await processor.CanProcess(response))
-                    {
-                        return await processor.Process(response);
-                    }
-                }
+                var initialProcessor = _pipelineFactory.Create();
+                return await initialProcessor.Process(response);
             }
             catch (Exception ex)
             {

--- a/source/Stahp/Stahp.Core/RequestTracer.cs
+++ b/source/Stahp/Stahp.Core/RequestTracer.cs
@@ -49,7 +49,7 @@ namespace Stahp.Core
 
         private async Task<TraceHop> GetNextHop(Uri url)
         {
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+            HttpRequestMessage request = new(HttpMethod.Get, url);
             try
             {
                 _logger.LogInformation("Starting trace for {url}", url);

--- a/source/Stahp/Stahp.Core/Stahp.Core.csproj
+++ b/source/Stahp/Stahp.Core/Stahp.Core.csproj
@@ -5,6 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  
+  <ItemGroup>
+	  <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+		  <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+	  </AssemblyAttribute>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.1" />

--- a/source/Stahp/Stahp.Core/Stahp.Core.csproj
+++ b/source/Stahp/Stahp.Core/Stahp.Core.csproj
@@ -7,11 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="AngleSharp" Version="1.0.1" />
+    <PackageReference Include="AngleSharp.Js" Version="0.15.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Whois" Version="3.0.1" />
   </ItemGroup>
 

--- a/source/Stahp/Stahp.Core/TraceHop.cs
+++ b/source/Stahp/Stahp.Core/TraceHop.cs
@@ -8,7 +8,8 @@ namespace Stahp.Core
     {
         public Uri Url { get; set; }
         public HttpStatusCode? HttpStatusCode { get; set; }
-        public bool Redirects { get; set; }
+        public RedirectType RedirectType { get; set; }
+        public bool Redirects => RedirectType != RedirectType.None;
 
         public string? ErrorMessage { get; set; }
 
@@ -31,6 +32,10 @@ namespace Stahp.Core
         public TraceHop(Uri url, HttpStatusCode httpStatusCode) : this(url)
         {
             HttpStatusCode = httpStatusCode;
+            RedirectType =
+                httpStatusCode >= System.Net.HttpStatusCode.Moved && httpStatusCode <= System.Net.HttpStatusCode.PermanentRedirect
+                ? RedirectType.Http
+                : RedirectType.None;
         }
 
         public TraceHop(Uri url, Exception exception) : this(url)

--- a/source/Stahp/Stahp.sln
+++ b/source/Stahp/Stahp.sln
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stahp.Core.Tests", "Stahp.Core.Tests\Stahp.Core.Tests.csproj", "{92FC09B0-ABCE-44CE-A9A2-51354A7314B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stahp.Core.Tests", "Stahp.Core.Tests\Stahp.Core.Tests.csproj", "{92FC09B0-ABCE-44CE-A9A2-51354A7314B8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/source/Stahp/Stahp.sln
+++ b/source/Stahp/Stahp.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stahp.Core.Tests", "Stahp.Core.Tests\Stahp.Core.Tests.csproj", "{92FC09B0-ABCE-44CE-A9A2-51354A7314B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{A3F0F820-0F74-46D6-BB7D-52509B0FF416}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3F0F820-0F74-46D6-BB7D-52509B0FF416}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3F0F820-0F74-46D6-BB7D-52509B0FF416}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92FC09B0-ABCE-44CE-A9A2-51354A7314B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92FC09B0-ABCE-44CE-A9A2-51354A7314B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92FC09B0-ABCE-44CE-A9A2-51354A7314B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92FC09B0-ABCE-44CE-A9A2-51354A7314B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
AngleSharp.Js provides various contexts for Jint so that we essentially get an in-process browser. It will execute Javascript when content is loaded, and provides a mechanism to trigger other events.

As part of these changes, HtmlAgilityPack was removed in favour of AngleSharp. A `RedirectType` enum and property on `TraceHop` was added so that redirects triggered by HTML `<meta>` tags and JavaScript can be separately identified.

This will resolve #3 
 